### PR TITLE
Remove unnecessary Arc

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,5 +1,5 @@
 use tokio::sync::Mutex;
-use std::{time::{SystemTime, UNIX_EPOCH}, collections::VecDeque, sync::{atomic::{Ordering, AtomicIsize}, Arc}};
+use std::{time::{SystemTime, UNIX_EPOCH}, collections::VecDeque, sync::{atomic::{Ordering, AtomicIsize}}};
 
 use app::json::JsonMessage;
 use actix_web::{get, web, Responder, HttpResponse, HttpServer, App, post};
@@ -14,13 +14,13 @@ struct QueueMessage {
 }
 
 struct MyQueue {
-    queue: Arc<Mutex<VecDeque<QueueMessage>>>,
+    queue: Mutex<VecDeque<QueueMessage>>,
 }
 
 impl Default for MyQueue {
     fn default() -> Self {
         return MyQueue {
-            queue: Arc::new(Mutex::new(VecDeque::new())),
+            queue: Mutex::new(VecDeque::new()),
         }
     }
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,5 +1,5 @@
 use tokio::sync::Mutex;
-use std::{time::{SystemTime, UNIX_EPOCH}, collections::VecDeque, sync::{atomic::{Ordering, AtomicIsize}}};
+use std::{time::{SystemTime, UNIX_EPOCH}, collections::VecDeque};
 
 use app::json::JsonMessage;
 use actix_web::{get, web, Responder, HttpResponse, HttpServer, App, post};


### PR DESCRIPTION
`MyQueue` is stored inside `web::Data` that internally uses an Arc for reference counting so there is no need to do it twice.

Also I cleaned up imports after removing atomic.