### PR TITLE
Messing around with a lockfree Set

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,27 +1,66 @@
-use tokio::sync::Mutex;
-use std::{time::{SystemTime, UNIX_EPOCH}, collections::VecDeque, sync::{atomic::{Ordering, AtomicIsize}, Arc}};
+use lockfree::prelude::Set;
+use std::{
+    hash::Hash,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
 
+use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
 use app::json::JsonMessage;
-use actix_web::{get, web, Responder, HttpResponse, HttpServer, App, post};
 
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-struct QueueMessage {
-    time: u128,
+fn gen_id() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
 
+#[derive(Debug)]
+struct Item {
+    id: u64,
+    time: u128,
     message: JsonMessage,
 }
 
+impl PartialEq for Item {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl PartialOrd for Item {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.id.partial_cmp(&other.id)
+    }
+}
+
+impl Eq for Item {}
+
+impl Ord for Item {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl Hash for Item {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state)
+    }
+}
+
 struct MyQueue {
-    queue: Arc<Mutex<VecDeque<QueueMessage>>>,
+    queue: Arc<Set<Item>>,
 }
 
 impl Default for MyQueue {
     fn default() -> Self {
         return MyQueue {
-            queue: Arc::new(Mutex::new(VecDeque::new())),
-        }
+            queue: Arc::new(Set::new()),
+        };
     }
 }
 
@@ -34,29 +73,42 @@ fn get_now() -> u128 {
 }
 
 impl MyQueue {
-    async fn empty_queue(&self, now: u128, msg: Option<QueueMessage>) -> usize {
-        let mut queue = self.queue.lock().await;
-        while let Some(item) = queue.get(0) {
+    async fn empty_queue(&self, now: u128, msg: Option<Item>) -> usize {
+        let mut count = 0;
+
+        for item in self.queue.iter() {
             if item.time < now {
-                queue.pop_front();
+                self.queue.remove(&item);
             } else {
-                break;
+                count += 1;
             }
         }
-        msg.map(|x| {
-            queue.push_back(x);
-        });
-        queue.len()
+
+        if let Some(msg) = msg {
+            self.queue.insert(msg).ok();
+            count += 1;
+        }
+
+        count
     }
 }
 
 #[post("/json/{time_in_queue}")]
-async fn json(req: web::Json<JsonMessage>, data: web::Data<MyQueue>, time_in_queue: web::Path<usize>) -> impl Responder {
+async fn json(
+    req: web::Json<JsonMessage>,
+    data: web::Data<MyQueue>,
+    time_in_queue: web::Path<usize>,
+) -> impl Responder {
     let now = get_now();
-    data.empty_queue(now, Some(QueueMessage {
-        time: now + (*time_in_queue as u128),
-        message: req.0,
-    })).await;
+    data.empty_queue(
+        now,
+        Some(Item {
+            id: gen_id(),
+            time: now + (*time_in_queue as u128),
+            message: req.0,
+        }),
+    )
+    .await;
 
     let resp = HttpResponse::Ok()
         .content_type("text/html")
@@ -79,7 +131,8 @@ async fn status(data: web::Data<MyQueue>) -> impl Responder {
 
 #[tokio::main] // or #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    let workers: usize = str::parse(&std::env::var("WORKERS").unwrap_or("1".to_string())).unwrap_or(1);
+    let workers: usize =
+        str::parse(&std::env::var("WORKERS").unwrap_or("1".to_string())).unwrap_or(1);
 
     let topics: web::Data<MyQueue> = web::Data::new(MyQueue::default());
 
@@ -95,6 +148,3 @@ async fn main() -> std::io::Result<()> {
     .run()
     .await
 }
-
-
-


### PR DESCRIPTION
Haven't tested this at all, so it could be a lot worse idk. I think a custom hasher would boost performance a lot, but I'm too lazy.

Also there was a bug with the original code. When emptying the queue, it stops at the first item which is not outdated, without checking the rest of the queue. Meaning any outdated items behind it will not be seen and removed. These changes make sure to check the entire queue, which is technically slower.

Another way to boost performance would be to individually schedule the removal of each item using time-out workers. This way we don't have to iterate over the items at all, just remove expired ones directly with their id. However this would stray pretty far from the comparison model.