### PR TITLE
go: improve queue performance, using sync.Pool

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -38,7 +38,7 @@ func main() {
             Message: json,
         }
 
-        q.Enqueue(&node)
+        q.Enqueue(node)
 		c.String(200, fmt.Sprintf("time in queue will be %v", tiq))
     })
 

--- a/pkg/queue/from
+++ b/pkg/queue/from
@@ -1,4 +1,0 @@
-BenchmarkQueue-4            1526           1605576 ns/op          800035 B/op      10001 allocs/op
-BenchmarkQueue-4            1762            670270 ns/op           12831 B/op        112 allocs/op
-
-

--- a/pkg/queue/from
+++ b/pkg/queue/from
@@ -1,0 +1,4 @@
+BenchmarkQueue-4            1526           1605576 ns/op          800035 B/op      10001 allocs/op
+BenchmarkQueue-4            1762            670270 ns/op           12831 B/op        112 allocs/op
+
+

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -49,6 +49,7 @@ func (q *Queue) Enqueue(qm QueueMessage) {
 		node = &Node{}
 	}
 	node.data = qm
+	node.next = nil
 
 	q.lock.Lock()
 	defer q.lock.Unlock()

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -1,0 +1,15 @@
+package queue
+
+import "testing"
+
+func BenchmarkQueue(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		q := NewQueue()
+		for i := 0; i < 100; i++ {
+			for i := 0; i < 100; i++ {
+				q.Enqueue(QueueMessage{Message: Message{message: "hello"}})
+			}
+			q.EmptyQueue()
+		}
+	}
+}


### PR DESCRIPTION
```
BenchmarkQueue-4            1526           1605576 ns/op          800035 B/op      10001 allocs/op
BenchmarkQueue-4            1762            670270 ns/op           12831 B/op        112 allocs/op
```
Queue is now ~2.4x faster.
```
func BenchmarkQueue(b *testing.B) {
	for i := 0; i < b.N; i++ {
		q := NewQueue()
		for i := 0; i < 100; i++ {
			for i := 0; i < 100; i++ {
				q.Enqueue(QueueMessage{Message: Message{message: "hello"}})
			}
			q.EmptyQueue()
		}
	}
}
```